### PR TITLE
Make Search form a Phlex component

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,13 +26,15 @@ gem 'rails', '~> 7.0', '>= 7.0.4.2'
 gem 'sd_notify', '~> 0.1.1'
 gem 'sitemap_generator'
 gem 'pundit'
-
+gem 'phlex-rails'
 
 group :development, :test do
   gem "debug", platforms: %i[ mri mingw x64_mingw ]
   gem 'faker'
   # gem "rails_live_reload"
   gem "dotenv-rails", "~> 2.7"
+
+  gem "lookbook", ">= 2.0.5"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,8 +104,11 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cgi (0.3.6)
     concurrent-ruby (1.2.2)
     crass (1.0.6)
+    css_parser (1.16.0)
+      addressable
     cssbundling-rails (1.1.1)
       railties (>= 6.0.0)
     date (3.3.3)
@@ -124,6 +127,8 @@ GEM
       dotenv (= 2.8.1)
       railties (>= 3.2)
     dry-initializer (3.1.1)
+    erb (4.0.3)
+      cgi (>= 0.3.3)
     erubi (1.12.0)
     faker (2.23.0)
       i18n (>= 1.8.11, < 2)
@@ -132,6 +137,8 @@ GEM
       activerecord (>= 4.0.0)
     globalid (1.1.0)
       activesupport (>= 5.0)
+    htmlbeautifier (1.4.2)
+    htmlentities (4.3.4)
     httparty (0.21.0)
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
@@ -154,6 +161,18 @@ GEM
     loofah (2.21.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
+    lookbook (2.0.5)
+      activemodel
+      css_parser
+      htmlbeautifier (~> 1.3)
+      htmlentities (~> 4.3.4)
+      marcel (~> 1.0)
+      railties (>= 5.0)
+      redcarpet (~> 3.5)
+      rouge (>= 3.26, < 5.0)
+      view_component (>= 2.0)
+      yard (~> 0.9.25)
+      zeitwerk (~> 2.5)
     mail (2.8.1)
       mini_mime (>= 0.1.1)
       net-imap
@@ -190,6 +209,14 @@ GEM
     orm_adapter (0.5.0)
     pagy (6.0.3)
     pg (1.4.4)
+    phlex (1.8.1)
+      concurrent-ruby (~> 1.2)
+      erb (>= 4)
+      zeitwerk (~> 2.6)
+    phlex-rails (1.0.0)
+      phlex (~> 1.7)
+      rails (>= 6.1, < 8)
+      zeitwerk (~> 2.6)
     public_suffix (5.0.3)
     puma (5.6.7)
       nio4r (~> 2.0)
@@ -234,6 +261,7 @@ GEM
       activerecord (>= 6.1.5)
       activesupport (>= 6.1.5)
       i18n
+    redcarpet (3.6.0)
     regexp_parser (2.8.1)
     reline (0.3.1)
       io-console (~> 0.5)
@@ -241,6 +269,7 @@ GEM
       actionpack (>= 5.0)
       railties (>= 5.0)
     rexml (3.2.6)
+    rouge (4.1.3)
     ruby-vips (2.1.4)
       ffi (~> 1.12)
     rubyzip (2.3.2)
@@ -285,6 +314,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+    yard (0.9.34)
     zeitwerk (2.6.8)
 
 PLATFORMS
@@ -308,9 +338,11 @@ DEPENDENCIES
   image_processing (~> 1.2)
   jbuilder
   jsbundling-rails
+  lookbook (>= 2.0.5)
   meta-tags
   pagy
   pg (~> 1.1)
+  phlex-rails
   puma (~> 5.6)
   pundit
   rack-canonical-host

--- a/app/views/application_view.rb
+++ b/app/views/application_view.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ApplicationView < ApplicationComponent
+	# The ApplicationView is an abstract class for all your views.
+
+	# By default, it inherits from `ApplicationComponent`, but you
+	# can change that to `Phlex::HTML` if you want to keep views and
+	# components independent.
+end

--- a/app/views/books/_index_nav.html.erb
+++ b/app/views/books/_index_nav.html.erb
@@ -18,22 +18,9 @@
       <%= link_to_unless_current "Testing", "/learn/testing", class: "text-red-500 hover:text-red-600" %>
     </span>
   </div>
-  <span>
-    <%= form_tag(books_path, method: "get", id: 'search_form', remote: true) do %>
-      <div class="flex items-center gap-2">
-        <label for="email" class="sr-only">Email</label>
-        <%= text_field_tag(:search_term, nil, placeholder: 'Search name', class: '"block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6"', value: html_escape(params[:search_term])) %>
-        <button type="submit" class="rounded-md bg-indigo-600 px-2.5 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Search</button>
-        <% if params[:search_term].present? %>
-          <%= link_to books_path, type: :submit, class: "rounded-full  p-1.5 text-indigo-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600", id: "clear-search-btn", title: "Reset search" do  %>
-            <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-5 h-5">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M9.75 9.75l4.5 4.5m0-4.5l-4.5 4.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-            </svg>
-          <% end %>
-        <% end %>
-      </div>
-    <% end %>
-  </span>
+  <div>
+    <%= render SearchComponent.new(path: books_path, search_term: params[:search_term]) %>
+  </div>
   <span class="h2">
     <% @random.each do |item| %>
       <%= link_to item, title: "Random Book", class: "text-red-500 hover:scale-110 transition" do %>

--- a/app/views/components/application_component.rb
+++ b/app/views/components/application_component.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class ApplicationComponent < Phlex::HTML
+	include Phlex::Rails::Helpers::Routes
+
+	if Rails.env.development?
+		def before_template
+			comment { "Before #{self.class.name}" }
+			super
+		end
+	end
+end

--- a/app/views/components/search_component.rb
+++ b/app/views/components/search_component.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+class SearchComponent < ApplicationComponent
+  def initialize(path:, search_term: nil)
+    @path = path
+    @search_term = ERB::Util.html_escape(search_term)
+  end
+
+  def template
+    form(id: "search_form", action: path, accept_charset: "UTF-8", data_remote: "true") do
+      div(class: "flex items-center gap-2") do
+        whitespace
+        label(for: "email", class: "sr-only") { "Email" }
+        whitespace
+        input(
+          name: "search_term",
+          id: "search_term",
+          value: search_term,
+          placeholder: "Search name",
+          class: INPUT_CLASS,
+          type: "text"
+        )
+        whitespace
+        button(type: "submit", class: SUBMIT_BUTTON_CLASS) { "Search" }
+
+        if search_term.present?
+          cancel_button
+        end
+      end
+    end
+  end
+
+  private
+
+  attr_reader :path, :search_term
+
+  INPUT_CLASS="block w-full rounded-md border-0 py-1.5 text-gray-900 shadow-sm ring-1 \
+  ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset \
+  focus:ring-indigo-600 sm:text-sm sm:leading-6"
+
+  SUBMIT_BUTTON_CLASS= "rounded-md bg-indigo-600 px-2.5 py-1.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 \
+  focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+
+  CANCEL_BUTTON_CLASS="rounded-full p-1.5 text-indigo-600 focus-visible:outline focus-visible:outline-2 \
+  focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+
+  private_constant :INPUT_CLASS, :SUBMIT_BUTTON_CLASS, :CANCEL_BUTTON_CLASS
+
+  def cancel_button
+    whitespace
+      a(type: "submit",class: CANCEL_BUTTON_CLASS, id: "clear-search-btn", title: "Reset search", href: path) do
+        whitespace
+        svg(
+          xmlns: "http://www.w3.org/2000/svg",
+          fill: "none",
+          viewbox: "0 0 24 24",
+          stroke_width: "1.5",
+          stroke: "currentColor",
+          class: "w-5 h-5"
+        ) do |s|
+          s.path(
+            stroke_linecap: "round",
+            stroke_linejoin: "round",
+            d: "M9.75 9.75l4.5 4.5m0-4.5l-4.5 4.5M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+          )
+        end
+      end
+  end
+end

--- a/app/views/layouts/component_preview.html.erb
+++ b/app/views/layouts/component_preview.html.erb
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%= javascript_include_tag "application", "data-turbo-track": "reload", defer: true %>
+    <%= favicon_link_tag "apple-touch-icon.png", rel: "apple-touch-icon", sizes: "180x180" %>
+    <%= favicon_link_tag "favicon-32x32.png", rel: "icon", sizes: "32x32", type: "image/png" %>
+    <%= favicon_link_tag "favicon-16x16.png", rel: "icon", color:"#EF4444" %>
+    <%= favicon_link_tag "safari-pinned-tab.svg", rel: "mask-icon", sizes: "16x16", type: "image/png" %>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;700&display=swap" rel="stylesheet">
+  </head>
+  <body class="flex items-center justify-center min-h-screen text-xl text-slate-800 bg-indigo-50">
+    <div class="relative flex flex-col gap-4 mx-auto overflow-clip lg:gap-10 lg:flex-row">
+      <%= yield %>
+    </div>
+  </body>
+</html>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,9 @@ Bundler.require(*Rails.groups)
 
 module RubyandrailsInfo
   class Application < Rails::Application
+    config.autoload_paths << "#{root}/app/views"
+    config.autoload_paths << "#{root}/app/views/layouts"
+    config.autoload_paths << "#{root}/app/views/components"
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
 
@@ -20,5 +23,8 @@ module RubyandrailsInfo
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.lookbook.project_name = "Ruby and Rails Info Preview"
+    config.lookbook.component_paths << "app/views/components"
+    config.lookbook.preview_layout = "component_preview"
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,8 @@
 Rails.application.routes.draw do
+  if Rails.env.development?
+    mount Lookbook::Engine, at: "/lookbook"
+  end
+
   resources :youtubes do
     resources :lessons, module: :youtubes
   end

--- a/test/components/previews/search_component_preview.rb
+++ b/test/components/previews/search_component_preview.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SearchComponentPreview < Lookbook::Preview
+  def default
+    render SearchComponent.new(path: "/books")
+  end
+
+  def with_previous_search_term
+    render SearchComponent.new(path: "/books", search_term: "Ruby")
+  end
+end


### PR DESCRIPTION
## What

This commit will:
- Add Phlex
- Move the books search form to a Phlex Component
- Add Lookbooks

## Why

- To prepare this for reuse and layout the structure for a design system

## How

Added Phlex and Lookbooks for previews. 
I moved Search Form to Phlex component and made it to accept the path and the current search term if any.

## Extra

This prepares the project to reuse the Search Form in all other pages. 

## PR checklist

- [x] This Pull Request is related to a single change. Unrelated changes should be opened in separate PRs.
- [x] Commit messages have a detailed description of what changed and why.
- [x] Tests are added or updated if you fix a bug or add a feature
- [x] PR has a description that includes _what_, _why_ and _how_
