### PR TITLE
Add seach component to all other pages

### DIFF
--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -1,39 +1,22 @@
 <% content_for :hero do %>
   <%= render "shared/page_title", title: "Courses about Ruby and Ruby on Rails", description: "Our collection of Ruby and Ruby on Rails courses cover everything from the basics to advanced topics like metaprogramming and web scraping. Courses will show you how to build powerful, production-ready web applications with this popular framework. Best of all, you can find courses for free. Ready to get started?", count: "#{Course.count} courses"  %>
 <% end %>
-
 <% content_for :content do %>
   <% if params[:search_term].present? %>
     <div class="pb-12">
       <strong>Search Term: </strong><%= params[:search_term] %>
     </div>
   <% end %>
-
   <div class="flex flex-wrap justify-between mb-8 xl:mb-16 gap-x-8 gap-y-2 md:gap-8">
     <span>
-      <h2 class="h2 mb-8">All Courses</h2>
+      <h2 class="mb-8 h2">All Courses</h2>
     </span>
-
     <span>
-      <%= form_tag(courses_path, method: "get", id: 'search_form', remote: true) do %>
-        <div class="input-group">
-          <span class="input-group-append">
-            <%= text_field_tag(:search_term, nil, placeholder: 'Search name', class: 'form-control', value: html_escape(params[:search_term])) %>    
-          </span>
-          <span class="input-group-append">
-            <button type="submit" class="btn btn-primary button-rounded", id="submit-search-btn", title="Search Courses">Search</button>
-            <%= link_to courses_path, type: :submit, class: "btn btn-warning", id: "clear-search-btn", title: "Reset", style: "margin-left: 10px; color: black" do  %> X <% end %>
-          </span>
-        </div>
-      <% end %>
+      <%= render(SearchComponent.new(path: courses_path, search_term: params[:search_term])) %>
     </span>
   </div>
-
   <div class="mb-8">
     <%= render partial: "courses/list", locals: { list: @courses } %>
   </div>
   <%== pagy_nav(@pagy) %>
 <% end %>
-
-
-

--- a/app/views/courses/index.html.erb
+++ b/app/views/courses/index.html.erb
@@ -8,12 +8,12 @@
     </div>
   <% end %>
   <div class="flex flex-wrap justify-between mb-8 xl:mb-16 gap-x-8 gap-y-2 md:gap-8">
-    <span>
+    <div>
       <h2 class="mb-8 h2">All Courses</h2>
-    </span>
-    <span>
+    </div>
+    <div>
       <%= render(SearchComponent.new(path: courses_path, search_term: params[:search_term])) %>
-    </span>
+    </div>
   </div>
   <div class="mb-8">
     <%= render partial: "courses/list", locals: { list: @courses } %>

--- a/app/views/newsletters/index.html.erb
+++ b/app/views/newsletters/index.html.erb
@@ -1,33 +1,19 @@
 <% content_for :hero do %>
   <%= render "shared/page_title", title: "Newsletters about Ruby and Ruby on Rails", description: "Get the latest news, tips, and tricks delivered right to your inbox. Read about interesting articles and blog posts about life and programming.", count: "#{Newsletter.count} newsletters"  %>
 <% end %>
-
 <% content_for :content do %>
   <% if params[:search_term].present? %>
     <div class="pb-12">
       <strong>Search Term: </strong><%= params[:search_term] %>
     </div>
   <% end %>
-
   <div class="flex flex-wrap justify-between mb-8 xl:mb-16 gap-x-8 gap-y-2 md:gap-8">
-    <span>
-      <h2 class="h2 mb-8">All Newsletters</h2>
-    </span>
-
-    <span>
-      <%= form_tag(newsletters_path, method: "get", id: 'search_form', remote: true) do %>
-        <div class="input-group">
-          <span class="input-group-append">
-            <%= text_field_tag(:search_term, nil, placeholder: 'Search name', class: 'form-control', value: html_escape(params[:search_term])) %>    
-          </span>
-          <span class="input-group-append">
-            <button type="submit" class="btn btn-primary button-rounded", id="submit-search-btn", title="Search Newletter">Search</button>
-            <%= link_to newsletters_path, type: :submit, class: "btn btn-warning", id: "clear-search-btn", title: "Reset", style: "margin-left: 10px; color: black" do  %> X <% end %>
-          </span>
-        </div>
-      <% end %>
-    </span>
+    <div>
+      <h2 class="mb-8 h2">All Newsletters</h2>
+    </div>
+    <div>
+      <%= render SearchComponent.new(path: newsletters_path, search_term: params[:search_term]) %>
+    </div>
   </div>
-
   <%= render partial: "newsletters/list", locals: { list: @newsletters } %>
 <% end %>

--- a/app/views/screencasts/index.html.erb
+++ b/app/views/screencasts/index.html.erb
@@ -1,34 +1,19 @@
 <% content_for :hero do %>
   <%= render "shared/page_title", title: "Screencasts about Ruby and Ruby on Rails", description: "If you're looking for some helpful resources on learning Ruby and Ruby on Rails development, I recommend checking out some screencast tutorials. There's a lot of great information out there that can help you get started and become a better developer. Happy learning!", count: "#{Screencast.count} courses"  %>
 <% end %>
-
 <% content_for :content do %>
   <% if params[:search_term].present? %>
     <div class="pb-12">
       <strong>Search Term: </strong><%= params[:search_term] %>
     </div>
   <% end %>
-
   <div class="flex flex-wrap justify-between mb-8 xl:mb-16 gap-x-8 gap-y-2 md:gap-8">
-    <span>
-      <h2 class="h2 mb-8">All Screencasts</h2>
-    </span>
-
-    <span>
-      <%= form_tag(screencasts_path, method: "get", id: 'search_form', remote: true) do %>
-        <div class="input-group">
-          <span class="input-group-append">
-            <%= text_field_tag(:search_term, nil, placeholder: 'Search name', class: 'form-control', value: html_escape(params[:search_term])) %>    
-          </span>
-          <span class="input-group-append">
-            <button type="submit" class="btn btn-primary button-rounded", id="submit-search-btn", title="Search Screencast">Search</button>
-            <%= link_to screencasts_path, type: :submit, class: "btn btn-warning", id: "clear-search-btn", title: "Reset", style: "margin-left: 10px; color: black" do  %> X <% end %>
-          </span>
-        </div>
-      <% end %>
-    </span>
+    <div>
+      <h2 class="mb-8 h2">All Screencasts</h2>
+    </div>
+    <div>
+      <%= render SearchComponent.new(path: screencasts_path, search_term: params[:search_term]) %>
+    </div>
   </div>
-
   <%= render partial: "screencasts/list", locals: { list: @screencasts } %>
 <% end %>
-

--- a/app/views/tags/index.html.erb
+++ b/app/views/tags/index.html.erb
@@ -1,37 +1,19 @@
 <% content_for :hero do %>
   <%= render "shared/page_title", title: "What would you like to learn more about? ", description: "If you're looking to learn more about programming, we've got a few resources that might interest you. Whatever your interest, we're sure we can find a book or course that's perfect for you.", count: "#{Tag.count} topics"  %>
 <% end %>
-
 <% content_for :content do %>
   <% if params[:search_term].present? %>
     <div class="pb-12">
       <strong>Search Term: </strong><%= params[:search_term] %>
     </div>
   <% end %>
-
   <div class="flex flex-wrap justify-between mb-8 xl:mb-16 gap-x-8 gap-y-2 md:gap-8">
     <span>
-      <h2 class="h2 mb-8">All Topics</h2>
+      <h2 class="mb-8 h2">All Topics</h2>
     </span>
-
-    <span>
-      <%= form_tag(tags_path, method: "get", id: 'search_form', remote: true) do %>
-        <div class="input-group">
-          <span class="input-group-append">
-            <%= text_field_tag(:search_term, nil, placeholder: 'Search name', class: 'form-control', value: html_escape(params[:search_term])) %>    
-          </span>
-          <span class="input-group-append">
-            <button type="submit" class="btn btn-primary button-rounded", id="submit-search-btn", title="Search Tags">Search</button>
-            <%= link_to tags_path, type: :submit, class: "btn btn-warning", id: "clear-search-btn", title: "Reset", style: "margin-left: 10px; color: black" do  %> X <% end %>
-          </span>
-        </div>
-      <% end %>
-    </span>
+    <div>
+      <%= render(SearchComponent.new(path: tags_path, search_term: params[:search_term])) %>
+    </div>
   </div>
-
   <%= render partial: "tags/list", locals: { list: @tags } %>
 <% end %>
-
-
-
-

--- a/app/views/youtubes/index.html.erb
+++ b/app/views/youtubes/index.html.erb
@@ -1,34 +1,19 @@
 <% content_for :hero do %>
   <%= render "shared/page_title", title: "YouTube Courses about Ruby and Ruby on Rails", description: "If you're interested in learning Ruby or Ruby on Rails, or if you want to brush up on your testing skills or learn more about other themes, you're in luck. There are plenty of free and paid books available on these topics. Whether you're a beginner or an expert, you're sure to find something that interests you.", count: "#{Youtube.count} YouTube Courses" %>
 <% end %>
-
 <% content_for :content do %>
   <% if params[:search_term].present? %>
     <div class="pb-12">
       <strong>Search Term: </strong><%= params[:search_term] %>
     </div>
   <% end %>
-
   <div class="flex flex-wrap justify-between mb-8 xl:mb-16 gap-x-8 gap-y-2 md:gap-8">
-    <span>
-      <h2 class="h2 mb-8">All YouTube Courses</h2>
-    </span>
-
-    <span>
-      <%= form_tag(youtubes_path, method: "get", id: 'search_form', remote: true) do %>
-        <div class="input-group">
-          <span class="input-group-append">
-            <%= text_field_tag(:search_term, nil, placeholder: 'Search name', class: 'form-control', value: html_escape(params[:search_term])) %>    
-          </span>
-          <span class="input-group-append">
-            <button type="submit" class="btn btn-primary button-rounded", id="submit-search-btn", title="Search Youtube Courses">Search</button>
-            <%= link_to youtubes_path, type: :submit, class: "btn btn-warning", id: "clear-search-btn", title: "Reset", style: "margin-left: 10px; color: black" do  %> X <% end %>
-          </span>
-        </div>
-      <% end %>
-    </span>
+    <div>
+      <h2 class="mb-8 h2">All YouTube Courses</h2>
+    </div>
+    <div>
+      <%= render SearchComponent.new(path: youtubes_path, search_term: params[:search_term]) %>
+    </div>
   </div>
-
   <%= render "youtubes/list" %>
 <% end %>
-


### PR DESCRIPTION
## What

This will replace the HTML search from all pages with the SearchComponent

## Why

The SearchComponent encapsulates the search form logic, making the code more readable and easier to change. It also takes care of HTML escaping the search_term, improving security. 

The form is now rendered inside a <div> instead of a <span> to follow HTML best practices.

## How

Replaced the HTML form in indexes pages with rendering the SearchComponent


## PR checklist

- [x] This Pull Request is related to a single change. Unrelated changes should be opened in separate PRs.
- [x] Commit messages have a detailed description of what changed and why.
- [x] Tests are added or updated if you fix a bug or add a feature
- [x] PR has a description that includes _what_, _why_ and _how_
