### PR TITLE
Rename search method and extract to test/helpers for reuse 

### DIFF
--- a/test/helpers/search_helper.rb
+++ b/test/helpers/search_helper.rb
@@ -1,7 +1,7 @@
 module Helpers
   module SearchHelper
-    def search_with_term(term)
-      fill_in 'search_term', with: term
+    def search_with_name(name)
+      fill_in 'search_term', with: name
       click_button 'Search'
     end
   end

--- a/test/helpers/search_helper.rb
+++ b/test/helpers/search_helper.rb
@@ -1,0 +1,8 @@
+module Helpers
+  module SearchHelper
+    def search_with_term(term)
+      fill_in 'search_term', with: term
+      click_button 'Search'
+    end
+  end
+end

--- a/test/helpers/search_helper.rb
+++ b/test/helpers/search_helper.rb
@@ -1,7 +1,7 @@
 module Helpers
   module SearchHelper
-    def search_with_name(name)
-      fill_in 'search_term', with: name
+    def search_with_term(term)
+      fill_in 'search_term', with: term
       click_button 'Search'
     end
   end

--- a/test/system/authors_test.rb
+++ b/test/system/authors_test.rb
@@ -25,7 +25,7 @@ class AuthorsTest < ApplicationSystemTestCase
 
     assert_selector "h3", text: author.name
 
-    search_with_name(author.name)
+    search_with_term(author.name)
     assert_equal true, page.has_content?("Search Term: #{author.name}")
 
     assert_selector "h3", text: author.name
@@ -37,7 +37,7 @@ class AuthorsTest < ApplicationSystemTestCase
 
     assert_selector "h3", text: author.name
 
-    search_with_name('invalid')
+    search_with_term('invalid')
     assert_equal true, page.has_content?("Search Term: invalid")
 
     # Page should not have that author

--- a/test/system/authors_test.rb
+++ b/test/system/authors_test.rb
@@ -25,7 +25,7 @@ class AuthorsTest < ApplicationSystemTestCase
 
     assert_selector "h3", text: author.name
 
-    search_author_name(author.name)
+    search_with_name(author.name)
     assert_equal true, page.has_content?("Search Term: #{author.name}")
 
     assert_selector "h3", text: author.name
@@ -37,17 +37,10 @@ class AuthorsTest < ApplicationSystemTestCase
 
     assert_selector "h3", text: author.name
 
-    search_author_name('invalid')
+    search_with_name('invalid')
     assert_equal true, page.has_content?("Search Term: invalid")
 
     # Page should not have that author
     refute_selector "h3", text: author.name
-  end
-
-  private
-
-  def search_author_name(name)
-    fill_in 'search_term', with: name
-    click_button 'Search'
   end
 end

--- a/test/system/books_test.rb
+++ b/test/system/books_test.rb
@@ -24,7 +24,7 @@ class BooksTest < ApplicationSystemTestCase
 
     assert_selector "h2", text: book.title
 
-    serach_book_title(book.title)
+    search_with_term(book.title)
     assert_equal true, page.has_content?("Search Term: #{book.title}")
 
     assert_selector "h2", text: book.title
@@ -36,17 +36,10 @@ class BooksTest < ApplicationSystemTestCase
 
     assert_selector "h2", text: book.title
 
-    serach_book_title('invalid')
+    search_with_term('invalid')
     assert_equal true, page.has_content?("Search Term: invalid")
 
     # Page should not have that book
     refute_selector "h2", text: book.title
-  end
-
-  private
-
-  def serach_book_title(title)
-    fill_in 'search_term', with: title
-    click_button 'Search'
   end
 end

--- a/test/system/books_test.rb
+++ b/test/system/books_test.rb
@@ -24,7 +24,7 @@ class BooksTest < ApplicationSystemTestCase
 
     assert_selector "h2", text: book.title
 
-    search_with_term(book.title)
+    search_with_name(book.title)
     assert_equal true, page.has_content?("Search Term: #{book.title}")
 
     assert_selector "h2", text: book.title
@@ -36,7 +36,7 @@ class BooksTest < ApplicationSystemTestCase
 
     assert_selector "h2", text: book.title
 
-    search_with_term('invalid')
+    search_with_name('invalid')
     assert_equal true, page.has_content?("Search Term: invalid")
 
     # Page should not have that book

--- a/test/system/books_test.rb
+++ b/test/system/books_test.rb
@@ -24,7 +24,7 @@ class BooksTest < ApplicationSystemTestCase
 
     assert_selector "h2", text: book.title
 
-    search_with_name(book.title)
+    search_with_term(book.title)
     assert_equal true, page.has_content?("Search Term: #{book.title}")
 
     assert_selector "h2", text: book.title
@@ -36,7 +36,7 @@ class BooksTest < ApplicationSystemTestCase
 
     assert_selector "h2", text: book.title
 
-    search_with_name('invalid')
+    search_with_term('invalid')
     assert_equal true, page.has_content?("Search Term: invalid")
 
     # Page should not have that book

--- a/test/system/communities_test.rb
+++ b/test/system/communities_test.rb
@@ -24,7 +24,7 @@ class CommunitiesTest < ApplicationSystemTestCase
 
     assert_selector "h2", text: community.title
 
-    search_with_term(community.title)
+    search_with_name(community.title)
     assert_equal true, page.has_content?("Search Term: #{community.title}")
 
     assert_selector "h2", text: community.title
@@ -36,7 +36,7 @@ class CommunitiesTest < ApplicationSystemTestCase
 
     assert_selector "h2", text: community.title
 
-    search_with_term('invalid')
+    search_with_name('invalid')
     assert_equal true, page.has_content?("Search Term: invalid")
 
     # Page should not have that community

--- a/test/system/communities_test.rb
+++ b/test/system/communities_test.rb
@@ -24,7 +24,7 @@ class CommunitiesTest < ApplicationSystemTestCase
 
     assert_selector "h2", text: community.title
 
-    serach_community_title(community.title)
+    search_with_term(community.title)
     assert_equal true, page.has_content?("Search Term: #{community.title}")
 
     assert_selector "h2", text: community.title
@@ -36,17 +36,10 @@ class CommunitiesTest < ApplicationSystemTestCase
 
     assert_selector "h2", text: community.title
 
-    serach_community_title('invalid')
+    search_with_term('invalid')
     assert_equal true, page.has_content?("Search Term: invalid")
 
     # Page should not have that community
     refute_selector "h2", text: community.title
-  end
-
-  private
-
-  def serach_community_title(title)
-    fill_in 'search_term', with: title
-    click_button 'Search'
   end
 end

--- a/test/system/communities_test.rb
+++ b/test/system/communities_test.rb
@@ -24,7 +24,7 @@ class CommunitiesTest < ApplicationSystemTestCase
 
     assert_selector "h2", text: community.title
 
-    search_with_name(community.title)
+    search_with_term(community.title)
     assert_equal true, page.has_content?("Search Term: #{community.title}")
 
     assert_selector "h2", text: community.title
@@ -36,7 +36,7 @@ class CommunitiesTest < ApplicationSystemTestCase
 
     assert_selector "h2", text: community.title
 
-    search_with_name('invalid')
+    search_with_term('invalid')
     assert_equal true, page.has_content?("Search Term: invalid")
 
     # Page should not have that community

--- a/test/system/courses_test.rb
+++ b/test/system/courses_test.rb
@@ -25,7 +25,7 @@ class CoursesTest < ApplicationSystemTestCase
 
     assert_selector "h3", text: course.title
 
-    search_with_term(course.title)
+    search_with_name(course.title)
     assert_equal true, page.has_content?("Search Term: #{course.title}")
 
     assert_selector "h3", text: course.title
@@ -37,7 +37,7 @@ class CoursesTest < ApplicationSystemTestCase
 
     assert_selector "h3", text: course.title
 
-    search_with_term('invalid')
+    search_with_name('invalid')
     assert_equal true, page.has_content?("Search Term: invalid")
 
     # Page should not have that course

--- a/test/system/courses_test.rb
+++ b/test/system/courses_test.rb
@@ -25,7 +25,7 @@ class CoursesTest < ApplicationSystemTestCase
 
     assert_selector "h3", text: course.title
 
-    search_with_name(course.title)
+    search_with_term(course.title)
     assert_equal true, page.has_content?("Search Term: #{course.title}")
 
     assert_selector "h3", text: course.title
@@ -37,7 +37,7 @@ class CoursesTest < ApplicationSystemTestCase
 
     assert_selector "h3", text: course.title
 
-    search_with_name('invalid')
+    search_with_term('invalid')
     assert_equal true, page.has_content?("Search Term: invalid")
 
     # Page should not have that course

--- a/test/system/courses_test.rb
+++ b/test/system/courses_test.rb
@@ -25,7 +25,7 @@ class CoursesTest < ApplicationSystemTestCase
 
     assert_selector "h3", text: course.title
 
-    serach_course_title(course.title)
+    search_with_term(course.title)
     assert_equal true, page.has_content?("Search Term: #{course.title}")
 
     assert_selector "h3", text: course.title
@@ -37,17 +37,10 @@ class CoursesTest < ApplicationSystemTestCase
 
     assert_selector "h3", text: course.title
 
-    serach_course_title('invalid')
+    search_with_term('invalid')
     assert_equal true, page.has_content?("Search Term: invalid")
 
     # Page should not have that course
     refute_selector "h3", text: course.title
-  end
-
-  private
-
-  def serach_course_title(title)
-    fill_in 'search_term', with: title
-    click_button 'Search'
   end
 end

--- a/test/system/newsletters_test.rb
+++ b/test/system/newsletters_test.rb
@@ -25,7 +25,7 @@ class NewslettersTest < ApplicationSystemTestCase
 
     assert_selector "h3", text: newsletter.title
 
-    search_with_name(newsletter.title)
+    search_with_term(newsletter.title)
     assert_equal true, page.has_content?("Search Term: #{newsletter.title}")
 
     assert_selector "h3", text: newsletter.title
@@ -37,7 +37,7 @@ class NewslettersTest < ApplicationSystemTestCase
 
     assert_selector "h3", text: newsletter.title
 
-    search_with_name('invalid')
+    search_with_term('invalid')
     assert_equal true, page.has_content?("Search Term: invalid")
 
     # Page should not have that newsletter

--- a/test/system/newsletters_test.rb
+++ b/test/system/newsletters_test.rb
@@ -25,7 +25,7 @@ class NewslettersTest < ApplicationSystemTestCase
 
     assert_selector "h3", text: newsletter.title
 
-    search_newsletter_title(newsletter.title)
+    search_with_name(newsletter.title)
     assert_equal true, page.has_content?("Search Term: #{newsletter.title}")
 
     assert_selector "h3", text: newsletter.title
@@ -37,17 +37,10 @@ class NewslettersTest < ApplicationSystemTestCase
 
     assert_selector "h3", text: newsletter.title
 
-    search_newsletter_title('invalid')
+    search_with_name('invalid')
     assert_equal true, page.has_content?("Search Term: invalid")
 
     # Page should not have that newsletter
     refute_selector "h3", text: newsletter.title
-  end
-
-  private
-
-  def search_newsletter_title(title)
-    fill_in 'search_term', with: title
-    click_button 'Search'
   end
 end

--- a/test/system/screencasts_test.rb
+++ b/test/system/screencasts_test.rb
@@ -25,7 +25,7 @@ class ScreencastsTest < ApplicationSystemTestCase
 
     assert_selector "h3", text: screencast.title
 
-    search_with_term(screencast.title)
+    search_with_name(screencast.title)
     assert_equal true, page.has_content?("Search Term: #{screencast.title}")
 
     assert_selector "h3", text: screencast.title
@@ -37,7 +37,7 @@ class ScreencastsTest < ApplicationSystemTestCase
 
     assert_selector "h3", text: screencast.title
 
-    search_with_term('invalid')
+    search_with_name('invalid')
     assert_equal true, page.has_content?("Search Term: invalid")
 
     # Page should not have that screencast

--- a/test/system/screencasts_test.rb
+++ b/test/system/screencasts_test.rb
@@ -25,7 +25,7 @@ class ScreencastsTest < ApplicationSystemTestCase
 
     assert_selector "h3", text: screencast.title
 
-    search_with_name(screencast.title)
+    search_with_term(screencast.title)
     assert_equal true, page.has_content?("Search Term: #{screencast.title}")
 
     assert_selector "h3", text: screencast.title
@@ -37,7 +37,7 @@ class ScreencastsTest < ApplicationSystemTestCase
 
     assert_selector "h3", text: screencast.title
 
-    search_with_name('invalid')
+    search_with_term('invalid')
     assert_equal true, page.has_content?("Search Term: invalid")
 
     # Page should not have that screencast

--- a/test/system/screencasts_test.rb
+++ b/test/system/screencasts_test.rb
@@ -25,7 +25,7 @@ class ScreencastsTest < ApplicationSystemTestCase
 
     assert_selector "h3", text: screencast.title
 
-    serach_screencast_title(screencast.title)
+    search_with_term(screencast.title)
     assert_equal true, page.has_content?("Search Term: #{screencast.title}")
 
     assert_selector "h3", text: screencast.title
@@ -37,17 +37,10 @@ class ScreencastsTest < ApplicationSystemTestCase
 
     assert_selector "h3", text: screencast.title
 
-    serach_screencast_title('invalid')
+    search_with_term('invalid')
     assert_equal true, page.has_content?("Search Term: invalid")
 
     # Page should not have that screencast
     refute_selector "h3", text: screencast.title
-  end
-
-  private
-
-  def serach_screencast_title(title)
-    fill_in 'search_term', with: title
-    click_button 'Search'
   end
 end

--- a/test/system/tags_test.rb
+++ b/test/system/tags_test.rb
@@ -25,7 +25,7 @@ class TagsTest < ApplicationSystemTestCase
 
     assert_selector 'a', text: tag.title
 
-    search_with_term(tag.title)
+    search_with_name(tag.title)
     assert_equal true, page.has_content?("Search Term: #{tag.title}")
 
     assert_selector 'a', text: tag.title
@@ -37,7 +37,7 @@ class TagsTest < ApplicationSystemTestCase
 
     assert_selector 'a', text: tag.title
 
-    search_with_term('invalid')
+    search_with_name('invalid')
     assert_equal true, page.has_content?("Search Term: invalid")
 
     # Page should not have that tag

--- a/test/system/tags_test.rb
+++ b/test/system/tags_test.rb
@@ -25,7 +25,7 @@ class TagsTest < ApplicationSystemTestCase
 
     assert_selector 'a', text: tag.title
 
-    search_with_name(tag.title)
+    search_with_term(tag.title)
     assert_equal true, page.has_content?("Search Term: #{tag.title}")
 
     assert_selector 'a', text: tag.title
@@ -37,7 +37,7 @@ class TagsTest < ApplicationSystemTestCase
 
     assert_selector 'a', text: tag.title
 
-    search_with_name('invalid')
+    search_with_term('invalid')
     assert_equal true, page.has_content?("Search Term: invalid")
 
     # Page should not have that tag

--- a/test/system/tags_test.rb
+++ b/test/system/tags_test.rb
@@ -25,7 +25,7 @@ class TagsTest < ApplicationSystemTestCase
 
     assert_selector 'a', text: tag.title
 
-    serach_tag_title(tag.title)
+    search_with_term(tag.title)
     assert_equal true, page.has_content?("Search Term: #{tag.title}")
 
     assert_selector 'a', text: tag.title
@@ -37,17 +37,10 @@ class TagsTest < ApplicationSystemTestCase
 
     assert_selector 'a', text: tag.title
 
-    serach_tag_title('invalid')
+    search_with_term('invalid')
     assert_equal true, page.has_content?("Search Term: invalid")
 
     # Page should not have that tag
     refute_selector "a", text: tag.title
-  end
-
-  private
-
-  def serach_tag_title(title)
-    fill_in 'search_term', with: title
-    click_button 'Search'
   end
 end

--- a/test/system/youtubes_test.rb
+++ b/test/system/youtubes_test.rb
@@ -25,7 +25,7 @@ class YoutubesTest < ApplicationSystemTestCase
 
     assert_selector "h3", text: youtube_course.title
 
-    serach_youtube_course_title(youtube_course.title)
+    search_with_term(youtube_course.title)
     assert_equal true, page.has_content?("Search Term: #{youtube_course.title}")
 
     assert_selector "h3", text: youtube_course.title
@@ -37,17 +37,10 @@ class YoutubesTest < ApplicationSystemTestCase
 
     assert_selector "h3", text: youtube_course.title
 
-    serach_youtube_course_title('invalid')
+    search_with_term('invalid')
     assert_equal true, page.has_content?("Search Term: invalid")
 
     # Page should not have that course
     refute_selector "h3", text: youtube_course.title
-  end
-
-  private
-
-  def serach_youtube_course_title(title)
-    fill_in 'search_term', with: title
-    click_button 'Search'
   end
 end

--- a/test/system/youtubes_test.rb
+++ b/test/system/youtubes_test.rb
@@ -25,7 +25,7 @@ class YoutubesTest < ApplicationSystemTestCase
 
     assert_selector "h3", text: youtube_course.title
 
-    search_with_term(youtube_course.title)
+    search_with_name(youtube_course.title)
     assert_equal true, page.has_content?("Search Term: #{youtube_course.title}")
 
     assert_selector "h3", text: youtube_course.title
@@ -37,7 +37,7 @@ class YoutubesTest < ApplicationSystemTestCase
 
     assert_selector "h3", text: youtube_course.title
 
-    search_with_term('invalid')
+    search_with_name('invalid')
     assert_equal true, page.has_content?("Search Term: invalid")
 
     # Page should not have that course

--- a/test/system/youtubes_test.rb
+++ b/test/system/youtubes_test.rb
@@ -25,7 +25,7 @@ class YoutubesTest < ApplicationSystemTestCase
 
     assert_selector "h3", text: youtube_course.title
 
-    search_with_name(youtube_course.title)
+    search_with_term(youtube_course.title)
     assert_equal true, page.has_content?("Search Term: #{youtube_course.title}")
 
     assert_selector "h3", text: youtube_course.title
@@ -37,7 +37,7 @@ class YoutubesTest < ApplicationSystemTestCase
 
     assert_selector "h3", text: youtube_course.title
 
-    search_with_name('invalid')
+    search_with_term('invalid')
     assert_equal true, page.has_content?("Search Term: invalid")
 
     # Page should not have that course

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,8 @@
 ENV["RAILS_ENV"] ||= "test"
 require_relative "../config/environment"
 require "rails/test_help"
+require_relative "helpers/search_helper"
+
 
 class ActiveSupport::TestCase
   # Run tests in parallel with specified workers
@@ -10,4 +12,5 @@ class ActiveSupport::TestCase
   fixtures :all
 
   # Add more helper methods to be used by all tests here...
+  include Helpers::SearchHelper 
 end


### PR DESCRIPTION
## What

As mentioned in issue #106, I have cleaned search method defined in each system test file and moved to module in test/helpers for reuse purpose.

## Why

To refactor and clean code

## How

- Created new search_helper.rb module and defined common search method in it. 
- Used this search method in required test files.

## PR checklist

- [x] This Pull Request is related to a single change. Unrelated changes should be opened in separate PRs.
- [x] Commit messages have a detailed description of what changed and why.
- [x] Tests are added or updated if you fix a bug or add a feature
- [x] PR has a description that includes _what_, _why_ and _how_
